### PR TITLE
es6.cluster config element is redundant

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfigWithElastic.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfigWithElastic.scala
@@ -10,7 +10,6 @@ class CommonConfigWithElastic(resources: GridConfigResources) extends CommonConf
       migration = string("es.index.aliases.migration")
     ),
     url = string("es6.url"),
-    cluster =  string("es6.cluster"),
     shards = string("es6.shards").toInt,
     replicas = string("es6.replicas").toInt
   )

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
@@ -26,8 +26,6 @@ trait ElasticSearchClient extends ElasticSearchExecutions with GridLogging {
 
   def url: String
 
-  def cluster: String
-
   def imagesCurrentAlias: String
   def imagesMigrationAlias: String
   lazy val imagesHistoricalAlias: String = "Images_Historical"

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchConfig.scala
@@ -1,3 +1,3 @@
 package com.gu.mediaservice.lib.elasticsearch
 
-case class ElasticSearchConfig(aliases: ElasticSearchAliases, url: String, cluster: String, shards: Int, replicas: Int)
+case class ElasticSearchConfig(aliases: ElasticSearchAliases, url: String, shards: Int, replicas: Int)

--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -131,7 +131,6 @@ function getMediaApiConfig(config) {
         |s3.usagemail.bucket="${config.coreStackProps.UsageMailBucket}"
         |persistence.identifier="picdarUrn"
         |es6.url="${config.es6.url}"
-        |es6.cluster="${config.es6.cluster}"
         |es6.shards=${config.es6.shards}
         |es6.replicas=${config.es6.replicas}
         |quota.store.key="rcs-quota.json"
@@ -173,7 +172,6 @@ function getThrallConfig(config) {
         |persistence.identifier="picdarUrn"
         |indexed.image.sns.topic.arn="${config.coreStackProps.IndexedImageTopic}"
         |es6.url="${config.es6.url}"
-        |es6.cluster="${config.es6.cluster}"
         |es6.shards=${config.es6.shards}
         |es6.replicas=${config.es6.replicas}
         |metrics.request.enabled=false

--- a/docs/06-objects-of-interest/02-config.md
+++ b/docs/06-objects-of-interest/02-config.md
@@ -879,12 +879,6 @@ Service-specific configs. These will override all other config files.
     <td></td>
   </tr>
   <tr>
-    <td><code>es6.cluster</code></td>
-    <td></td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
     <td><code>es6.shards</code></td>
     <td></td>
     <td></td>
@@ -1195,12 +1189,6 @@ Service-specific configs. These will override all other config files.
   </tr>
   <tr>
     <td><code>es6.url</code></td>
-    <td></td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td><code>es6.cluster</code></td>
     <td></td>
     <td></td>
     <td></td>

--- a/docs/99-archives/elasticsearch6.md
+++ b/docs/99-archives/elasticsearch6.md
@@ -31,7 +31,6 @@ es.index.aliases.current=Images_Current
 es.index.aliases.migration=Images_Migration
 
 es6.url=http://elastic6.local:9200
-es6.cluster=media-service
 es6.shards=5
 es6.replicas=2
 ```

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -43,7 +43,6 @@ class ElasticSearch(
   lazy val imagesCurrentAlias = elasticConfig.aliases.current
   lazy val imagesMigrationAlias = elasticConfig.aliases.migration
   lazy val url = elasticConfig.url
-  lazy val cluster = elasticConfig.cluster
   lazy val shards = elasticConfig.shards
   lazy val replicas = elasticConfig.replicas
 

--- a/media-api/test/lib/elasticsearch/Fixtures.scala
+++ b/media-api/test/lib/elasticsearch/Fixtures.scala
@@ -36,7 +36,6 @@ trait Fixtures {
     "es.index.aliases.current",
     "es.index.aliases.migration",
     "es6.url",
-    "es6.cluster",
     "s3.image.bucket",
     "s3.thumb.bucket",
     "grid.stage",

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -39,7 +39,6 @@ class ElasticSearch(
   lazy val imagesCurrentAlias: String = config.aliases.current
   lazy val imagesMigrationAlias: String = config.aliases.migration
   lazy val url: String = config.url
-  lazy val cluster: String = config.cluster
   lazy val shards: Int = config.shards
   lazy val replicas: Int = config.replicas
 


### PR DESCRIPTION
## What does this change?

Remove the redundant `es6.cluster` configuration element.

Elasticsearch 6 clients locate the cluster by service URL.
This config element appears to be unused. It possibly dates from the Elasticsearch 1 to 6 migration.

## How should a reviewer test this change?

Thrall complies and starts up; is still able to connect to Elasticsearch.

## How can success be measured?

Should have zero impact on running Grid instances. Removes a potentially confusing mandatory field from the Elastic setup.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
