### PR TITLE
Neuter cloudwatch

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metrics/CloudWatchMetrics.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metrics/CloudWatchMetrics.scala
@@ -84,9 +84,13 @@ abstract class CloudWatchMetrics(namespace: String, config: CommonConfig) {
       .toSeq
 
     aggregatedMetrics.grouped(20).foreach(chunkedMetrics => { //can only send max 20 metrics to CW at a time
-      client.putMetricData(new PutMetricDataRequest()
+      /*
+        Yeah nah
+        client.putMetricData(new PutMetricDataRequest()
         .withNamespace(namespace)
         .withMetricData(chunkedMetrics.asJava))
+      }
+       */
       }
     )
 

--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -170,7 +170,6 @@ function getThrallConfig(config) {
         |s3.thumb.bucket="${config.coreStackProps.ThumbBucket}"
         |s3.reaper.bucket="${config.coreStackProps.ReaperBucket}"
         |persistence.identifier="picdarUrn"
-        |indexed.image.sns.topic.arn="${config.coreStackProps.IndexedImageTopic}"
         |es6.url="${config.es6.url}"
         |es6.shards=${config.es6.shards}
         |es6.replicas=${config.es6.replicas}

--- a/docs/06-objects-of-interest/02-config.md
+++ b/docs/06-objects-of-interest/02-config.md
@@ -1182,12 +1182,6 @@ Service-specific configs. These will override all other config files.
     <td></td>
   </tr>
   <tr>
-    <td><code>indexed.image.sns.topic.arn</code></td>
-    <td></td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
     <td><code>es6.url</code></td>
     <td></td>
     <td></td>

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -25,7 +25,6 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
   final override val buildInfo = utils.buildinfo.BuildInfo
 
   val store = new ThrallStore(config)
-  val metadataEditorNotifications = new MetadataEditorNotifications(config)
   val thrallMetrics = new ThrallMetrics(config)
 
   val es = new ElasticSearch(config.esConfig, Some(thrallMetrics), actorSystem.scheduler)
@@ -60,7 +59,6 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
     es,
     thrallMetrics,
     store,
-    metadataEditorNotifications,
     actorSystem
   )
 

--- a/thrall/app/lib/MetadataEditorNotifications.scala
+++ b/thrall/app/lib/MetadataEditorNotifications.scala
@@ -5,6 +5,5 @@ import play.api.libs.json.Json
 
 import scala.concurrent.ExecutionContext
 
-class MetadataEditorNotifications(config: ThrallConfig) extends SNS(config, config.metadataTopicArn) {
-  def publishImageDeletion(id: String)(implicit ec: ExecutionContext) = publish(Json.obj("id" -> id), "image-deleted")
+class MetadataEditorNotifications(config: ThrallConfig) {
 }

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -41,8 +41,6 @@ class ThrallConfig(resources: GridConfigResources) extends CommonConfigWithElast
   val maybeReaperBucket: Option[String] = stringOpt("s3.reaper.bucket")
   val maybeReaperCountPerRun: Option[Int] = intOpt("reaper.countPerRun")
 
-  val metadataTopicArn: String = string("indexed.image.sns.topic.arn")
-
   val rewindFrom: Option[DateTime] = stringOpt("thrall.kinesis.stream.rewindFrom").map(ISODateTimeFormat.dateTime.parseDateTime)
   val lowPriorityRewindFrom: Option[DateTime] = stringOpt("thrall.kinesis.lowPriorityStream.rewindFrom").map(ISODateTimeFormat.dateTime.parseDateTime)
 

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -19,7 +19,7 @@ case class KinesisReceiverConfig(
   override val isDev: Boolean,
   streamName: String,
   rewindFrom: Option[DateTime],
-  metricsLevel: MetricsLevel = MetricsLevel.DETAILED
+  metricsLevel: MetricsLevel = MetricsLevel.NONE
 ) extends AwsClientBuilderUtils
 
 object KinesisReceiverConfig {

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -25,7 +25,6 @@ case class InsertImageFailure(message: String) extends Exception(message) with M
 class MessageProcessor(
   es: ElasticSearch,
   store: ThrallStore,
-  metadataEditorNotifications: MetadataEditorNotifications,
 ) extends GridLogging with MessageSubjects {
 
   def process(updateMessage: ThrallMessage, logMarker: LogMarker)(implicit ec: ExecutionContext): Future[Any] = {

--- a/thrall/app/lib/kinesis/ThrallEventConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallEventConsumer.scala
@@ -17,7 +17,6 @@ import scala.util.{Failure, Success, Try}
 class ThrallEventConsumer(es: ElasticSearch,
   thrallMetrics: ThrallMetrics,
   store: ThrallStore,
-  metadataEditorNotifications: MetadataEditorNotifications,
   actorSystem: ActorSystem
 ) extends PlayJsonHelpers with GridLogging {
 
@@ -26,7 +25,7 @@ class ThrallEventConsumer(es: ElasticSearch,
   private val attempts = 2
   private val timeout = attemptTimeout * attempts + delay * (attempts - 1)
 
-  private val messageProcessor = new MessageProcessor(es, store, metadataEditorNotifications)
+  private val messageProcessor = new MessageProcessor(es, store)
 
   private implicit val implicitActorSystem: ActorSystem = actorSystem
 


### PR DESCRIPTION
## What does this change?

CloudWatch is noisy and expensive and baked in everywhere in the AWS client libraries.
Do not want.
Disable and then look to make configurable.


## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
